### PR TITLE
Fix crash

### DIFF
--- a/imgui/imgui.cpp
+++ b/imgui/imgui.cpp
@@ -1695,6 +1695,10 @@ void ImGuiIO::ClearInputCharacters()
 static ImGuiInputEvent* FindLatestInputEvent(ImGuiContext* ctx, ImGuiInputEventType type, int arg = -1)
 {
     ImGuiContext& g = *ctx;
+    
+    if (g.InputEventsQueue.Size <= 0)
+        return NULL;
+    
     for (int n = g.InputEventsQueue.Size - 1; n >= 0; n--)
     {
         ImGuiInputEvent* e = &g.InputEventsQueue[n];


### PR DESCRIPTION
fix #8 
```
Thread 1 "cs2" received signal SIGABRT, Aborted.
0x00007f1c448aa0fb in pthread_kill () from target:/usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/libc.so.6
(gdb) bt full
#0  0x00007f1c448aa0fb in pthread_kill () from target:/usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#1  0x00007f1c448447c8 in raise () from target:/usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#2  0x00007f1c4482560d in abort () from target:/usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#3  0x00007f1c44825578 in ?? () from target:/usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#4  0x00007f1c4483aeb6 in __assert_fail ()
   from target:/usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/libc.so.6
No symbol table info available.
#5  0x00007f1ae6dc9445 in ImVector<ImGuiInputEvent>::operator[] (this=0x7f1bae0f9568, i=0) at imgui/imgui.h:2185
        __PRETTY_FUNCTION__ = "T& ImVector<T>::operator[](int) [with T = ImGuiInputEvent]"
#6  0x00007f1ae6d87582 in FindLatestInputEvent (ctx=0x7f1bae0f81b0, type=ImGuiInputEventType_MousePos, arg=-1)
    at imgui/imgui.cpp:1700
```